### PR TITLE
Add additional tests on the check_markov_trace function

### DIFF
--- a/R/check_markov_trace.R
+++ b/R/check_markov_trace.R
@@ -51,15 +51,7 @@ check_markov_trace <- function(m_TR,
   no_warnings <- T
 
   # Check that the matrix contains numeric values
-  if (!is.numeric(m_TR)) {
-    message <- "Markov trace is not numeric"
-    no_warnings <- F
-    if (stop_if_not) {
-      stop(message)
-    } else{
-      warning(message)
-    }
-  }
+  if (!is.numeric(m_TR))  stop("Markov trace is not numeric")
 
   # Check that matrix values are between 0 and 1
   if (!all(m_TR >= 0 & m_TR <= 1)) {

--- a/R/check_markov_trace.R
+++ b/R/check_markov_trace.R
@@ -46,6 +46,7 @@ check_markov_trace <- function(m_TR,
   # check the trace is named!
   m_TR_colnames <- colnames(m_TR)
   if(any(is.na(m_TR_colnames)) | any(is.null(m_TR_colnames))) warning("m_TR is missing one or more column names")
+  if(length(unique(m_TR_colnames)) != ncol(m_TR)) stop("m_TR has duplicate column names")
 
   # Start with no warnings
   no_warnings <- T
@@ -79,8 +80,13 @@ check_markov_trace <- function(m_TR,
   if(!is.null(dead_state)){
     # Check that rows sum to 1, indicating valid transition probabilities
     if(!all(diff(x = m_TR[, dead_state]) >= 0)){
-      message("Warning: Decreasing proportion in the dead state of trace, is this correct?")
-      confirm_ok <- F
+      no_warnings <- F
+      message <- "Decreasing proportion in the dead state of trace, is this correct?"
+      if (stop_if_not) {
+        stop(message)
+      } else{
+        warning(message)
+      }
     }
   }
 

--- a/man/check_trans_prob_array.Rd
+++ b/man/check_trans_prob_array.Rd
@@ -37,11 +37,11 @@ for(x in 1:1000){
   diag(a_P[,,x]) <- 1 - rowSums(a_P[,,x])
 }
 
-check_trans_prob_array(a_P = a_P, confirm_ok = F)
+check_trans_prob_array(a_P = a_P, stop_if_not = F)
 # introduce error
 a_P["H", "S", 1:10] <- 0
 
-check_trans_prob_array(a_P = a_P, confirm_ok = F)
+check_trans_prob_array(a_P = a_P, stop_if_not = F)
 
 }
 

--- a/tests/testthat/test-check_markov_trace.R
+++ b/tests/testthat/test-check_markov_trace.R
@@ -1,53 +1,97 @@
+
+# Create trace that conforms:
+v_hs_names <- c("H", "S", "D") # Three health states
+n_hs <- length(v_hs_names)
+n_t <- 10 # 10 time points
+# matrix structure
+m_TR <-
+  matrix(
+    data = NA,
+    nrow = n_t,
+    ncol = n_hs,
+    dimnames = list(NULL, v_hs_names)
+  )
+# dummy values that conform (dead proportion increase monotonically)
+m_TR[, "H"] <- seq(1, 0, length.out = n_t)
+m_TR[, "S"] <- seq(0, 0.5, length.out = n_t)
+m_TR[, "D"] <- 1 - m_TR[, "H"] - m_TR[, "S"]
+
+# create markov traces in which:
+# - the matrix contains non numeric values
+m_TR_non_numeric <- m_TR
+m_TR_non_numeric[1, 1] <- "a"
+
+# - the matrix contains values outside the range 0-1
+m_TR_outside_range <- m_TR
+m_TR_outside_range[1, 1] <- -1
+m_TR_outside_range[1, 2] <- 2 # done so the row still sums to 1
+
+# - the matrix contains rows that do not sum to 1
+m_TR_rows_not_sum_to_1 <- m_TR
+m_TR_rows_not_sum_to_1[1, 1] <- 0.5
+
+# - the matrix contains dead state values that do not increase monotonically
+m_TR_dead_not_monotonic <- m_TR
+m_TR_dead_not_monotonic[5, "D"] <- 0.5
+
+# remove unnecessary objects
+rm(n_hs, n_t, v_hs_names)
+
+
+#===========#
+# Run tests #
+#===========#
+
 test_that(desc = "check_markov_trace shouldn't issue warnings for valid input",
           code = {
-            v_hs_names <- c("H", "S", "D")
-            n_hs <- length(v_hs_names)
-            n_t <- 10
-            m_TR <-
-              matrix(
-                data = NA,
-                nrow = n_t,
-                ncol = n_hs,
-                dimnames = list(NULL, v_hs_names)
-              )
-
-            m_TR[, "H"] <- seq(1, 0, length.out = n_t)
-            m_TR[, "S"] <- seq(0, 0.5, length.out = n_t)
-            m_TR[, "D"] <- 1 - m_TR[, "H"] - m_TR[, "S"]
-
-
             expect_silent(check_markov_trace(m_TR))
+          })
+
+
+test_that(desc = "check_markov_trace should issue error for non-numeric values",
+          code = {
+
+            expect_error(
+              check_markov_trace(m_TR = m_TR_non_numeric, stop_if_not = T)
+            )
+
+          })
+
+test_that(desc = "check_markov_trace should issue warning & error for values outside the range 0-1",
+          code = {
+            expect_warning(
+              check_markov_trace(m_TR = m_TR_outside_range, stop_if_not = F)
+            )
+
+            expect_error(
+              check_markov_trace(m_TR = m_TR_outside_range, stop_if_not = T)
+            )
+
+          })
+
+
+test_that(desc = "check_markov_trace should issue warning & error for rows that do not sum to 1",
+          code = {
+            expect_warning(
+              check_markov_trace(m_TR = m_TR_rows_not_sum_to_1, stop_if_not = F)
+            )
+
+            expect_error(
+              check_markov_trace(m_TR = m_TR_rows_not_sum_to_1, stop_if_not = T)
+            )
 
           })
 
 
 
-
-test_that(desc = "check_markov_trace shouldn't issue warnings for valid input",
+test_that(desc = "check_markov_trace should issue warning & error for dead state values that do not increase monotonically",
           code = {
-            v_hs_names <- c("H", "S", "D")
-            n_hs <- length(v_hs_names)
-            n_t <- 10
-            m_TR <-
-              matrix(
-                data = NA,
-                nrow = n_t,
-                ncol = n_hs,
-                dimnames = list(NULL, v_hs_names)
-              )
-
-            m_TR[, "H"] <- seq(1, 0, length.out = n_t)
-            m_TR[, "S"] <- seq(0, 0.5, length.out = n_t)
-            m_TR[, "D"] <- 1 - m_TR[, "H"] - m_TR[, "S"]
-            m_TR[10, "D"] <- 0
-            m_TR[9, "S"] <- 1
-
             expect_warning(
-              check_markov_trace(m_TR = m_TR, stop_if_not = F)
+              check_markov_trace(m_TR = m_TR_dead_not_monotonic, stop_if_not = F)
             )
 
             expect_error(
-              check_markov_trace(m_TR = m_TR, stop_if_not = T)
+              check_markov_trace(m_TR = m_TR_dead_not_monotonic, stop_if_not = T)
             )
 
           })

--- a/tests/testthat/test-check_markov_trace.R
+++ b/tests/testthat/test-check_markov_trace.R
@@ -33,6 +33,17 @@ m_TR_rows_not_sum_to_1[1, 1] <- 0.5
 # - the matrix contains dead state values that do not increase monotonically
 m_TR_dead_not_monotonic <- m_TR
 m_TR_dead_not_monotonic[5, "D"] <- 0.5
+m_TR_dead_not_monotonic[5, "H"] <- 1 - m_TR_dead_not_monotonic[5, "D"] - m_TR_dead_not_monotonic[5, "S"]
+
+# - the matrix has 2 dimensions
+m_TR_3d <- array(data = 1, dim = c(n_t, n_hs, 10))
+m_TR_1d <- rep(1, n_t)
+
+# adjust column names
+m_TR_missing_column_name <- m_TR
+colnames(m_TR_missing_column_name) <- c("H", "S", NA)
+m_TR_duplicate_column_name <- m_TR
+colnames(m_TR_duplicate_column_name) <- c("H", "S", "H")
 
 # remove unnecessary objects
 rm(n_hs, n_t, v_hs_names)
@@ -87,11 +98,49 @@ test_that(desc = "check_markov_trace should issue warning & error for rows that 
 test_that(desc = "check_markov_trace should issue warning & error for dead state values that do not increase monotonically",
           code = {
             expect_warning(
-              check_markov_trace(m_TR = m_TR_dead_not_monotonic, stop_if_not = F)
+              check_markov_trace(m_TR = m_TR_dead_not_monotonic, stop_if_not = F, dead_state = "D")
             )
 
             expect_error(
-              check_markov_trace(m_TR = m_TR_dead_not_monotonic, stop_if_not = T)
+              check_markov_trace(m_TR = m_TR_dead_not_monotonic, stop_if_not = T, dead_state = "D")
+            )
+
+          })
+
+
+
+test_that(desc = "check_markov_trace should issue error for 1d or 3d arrays",
+          code = {
+            expect_error(
+              check_markov_trace(m_TR = m_TR_3d, stop_if_not = T)
+            )
+
+            expect_error(
+              check_markov_trace(m_TR = m_TR_1d, stop_if_not = T)
+            )
+
+          })
+
+
+
+test_that(desc = "check_markov_trace issues warning for missing column name and error for duplicate column name",
+          code = {
+            expect_warning(
+              check_markov_trace(m_TR = m_TR_missing_column_name, stop_if_not = T)
+            )
+
+            expect_error(
+              check_markov_trace(m_TR = m_TR_duplicate_column_name, stop_if_not = T)
+            )
+
+          })
+
+
+test_that(desc = "Check confirm OK works as expected",
+          code = {
+            expect_match(
+              check_markov_trace(m_TR = m_TR, stop_if_not = T, confirm_ok = T),
+              "Markov Trace passed all checks."
             )
 
           })


### PR DESCRIPTION
Added additional tests on the `check_markov_trace` function which increase code coverage.

As a result added some additional functionality to the function:
- check for duplicate column names
- add error message for increasing dead state.
- stop (rather than warn) for non-numeric values. This is done because all other checks fail if non-numeric values