### PR TITLE
Remove need to source functions for project_visualiser() to main environment

### DIFF
--- a/R/utils-file.R
+++ b/R/utils-file.R
@@ -179,6 +179,7 @@ source_files <- function( file_regx = ".R",
 #' sourcing *this* file is a mistake - may result in infinite recursion
 #' @param file = a connection object or a character string path to a file.
 #' @param lines = A vector of integers specifying the lines to be sourced.
+#' @param env the environment in which to source the lines
 #'
 #' @return NULL
 #'
@@ -191,7 +192,7 @@ source_files <- function( file_regx = ".R",
 #'              lines = c(4, 5, 6) )     ## source lines 4-6
 #' }
 #'
-source_lines <- function(file, lines){
+source_lines <- function(file, lines, env = .GlobalEnv){
 
   # Check if 'file' is a character string
   if (is.character(file) && !file.exists(file)) {
@@ -209,7 +210,7 @@ source_lines <- function(file, lines){
   connection <- textConnection(object = selected_lines)
 
   # source the lines of code
-  source(connection)
+  source(connection, local = env)
 
 }
 
@@ -218,6 +219,7 @@ source_lines <- function(file, lines){
 #' # IMPORTANT !!!
 #' sourcing *this* file is a mistake - may result in infinite recursion
 #' @param file = a connection object or a character string path to a file.
+#' @param env the environment in which to source the functions
 #'
 #' @return NULL
 #'
@@ -230,7 +232,7 @@ source_lines <- function(file, lines){
 #' source_funcs(file)
 #' }
 #'
-source_funcs <- function(file){
+source_funcs <- function(file, env = .GlobalEnv){
 
   # identify which lines of the file are defining functions
   func_locs <- locate_funcs(file)
@@ -251,7 +253,8 @@ source_funcs <- function(file){
 
   # source the functions
   source_lines(file = file,
-               lines = func_lines)
+               lines = func_lines,
+               env = env)
 
 }
 

--- a/man/identify_dependencies.Rd
+++ b/man/identify_dependencies.Rd
@@ -4,10 +4,13 @@
 \alias{identify_dependencies}
 \title{Identify Dependencies}
 \usage{
-identify_dependencies(v_unique_foo)
+identify_dependencies(v_unique_foo, pkg_env = environment())
 }
 \arguments{
 \item{v_unique_foo}{Vector of unique function strings.}
+
+\item{pkg_env}{The package environment where the functions are defined
+(e.g. global).}
 }
 \value{
 A data.table with two columns ("from" and "to") representing the dependencies.

--- a/man/source_funcs.Rd
+++ b/man/source_funcs.Rd
@@ -4,10 +4,12 @@
 \alias{source_funcs}
 \title{source_funcs}
 \usage{
-source_funcs(file)
+source_funcs(file, env = .GlobalEnv)
 }
 \arguments{
 \item{file}{= a connection object or a character string path to a file.}
+
+\item{env}{the environment in which to source the functions}
 }
 \description{
 Sources \emph{only} the functions discovered in an R file

--- a/man/source_lines.Rd
+++ b/man/source_lines.Rd
@@ -4,12 +4,14 @@
 \alias{source_lines}
 \title{source_lines}
 \usage{
-source_lines(file, lines)
+source_lines(file, lines, env = .GlobalEnv)
 }
 \arguments{
 \item{file}{= a connection object or a character string path to a file.}
 
 \item{lines}{= A vector of integers specifying the lines to be sourced.}
+
+\item{env}{the environment in which to source the lines}
 }
 \description{
 Sources specified lines within a single file


### PR DESCRIPTION
Within the `project_visualiser()` function it was noted that:

``` r 
# the scripts must be loaded in the namespace...
# so we have to source them all before we can run the code.
# ideally we would not need to do this, although its hardly the end of the world
```

I agree it is not ideal to pollute the main environment with all functions, as this may potentially cause conflicts. 
Therefore this PR sources functions to a separate temporary environment.

Please note that `run_coverage = T` is failing for me irrespective of this change.