### PR TITLE
edit markov trace checker

### DIFF
--- a/R/check_markov_trace.R
+++ b/R/check_markov_trace.R
@@ -52,7 +52,7 @@ check_markov_trace <- function(m_TR,
   no_warnings <- T
 
   # Check that the matrix contains numeric values
-  if (!is.numeric(m_TR))  stop("Markov trace is not numeric")
+  if (!all(apply(m_TR, MARGIN = 2, is.numeric)))  stop("Markov trace is not numeric")
 
   # Check that matrix values are between 0 and 1
   if (!all(m_TR >= 0 & m_TR <= 1)) {


### PR DESCRIPTION
The Markov Trace checker was flagging matrices as non-numeric where all cells are numeric. Added in check by column and now works fine.