### PR TITLE
Minor edits to the add-in

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Suggests: 
     testthat (>= 3.0.0),
-    colourpicker
+    colourpicker,
+    clipr
 Config/testthat/edition: 3
 Depends:
     R (>= 3.5.0)

--- a/R/addin_handler.R
+++ b/R/addin_handler.R
@@ -170,7 +170,7 @@ visualise_project_addin <- function() {
         max = 1,
         value = c(0.2, 0.8)
       ),
-      shiny::checkboxInput("print_isolated_foo", "Print Isolated Functions", value = TRUE),
+      shiny::checkboxInput("print_isolated_foo", "Print Isolated Functions", value = FALSE),
       shiny::checkboxInput("scale_node_size_by_degree", "Scale Node Size by Degree", value = TRUE)
     )
   )
@@ -331,6 +331,10 @@ visualise_project_addin <- function() {
                         p_str12,
                         p_str13,
                         p_str14)
+   cat("\n\nFunction call:\n")
+   cat("\n", func_text, "\n\n")
 
-   cat("\n\n", func_text, "\n\n")
+   # copy the function call to the clipboard
+   clipr::write_clip(func_text)
+   cat("\n\n'assertHE::visualise_project' function call copied to the clipboard\n\n")
 }

--- a/R/project_visualiser.R
+++ b/R/project_visualiser.R
@@ -9,7 +9,7 @@
 #' @param exclude_files A regular expression for files to NOT process (basename)
 #' @param exclude_dirs A regular expression for directories to NOT process (dirname)
 #' @param run_coverage Boolean determining whether to run coverage assessment
-#' @param print_isolated_foo Print the isolated functions to the console.
+#' @param print_isolated_foo Print the isolated functions to the console (default false)
 #'
 #' @return A visNetwork object representing the network plot of function dependencies.
 #'
@@ -43,7 +43,7 @@ visualise_project <- function(project_path,
                               color_with_test = c("background" = "#e6ffe6", "border" = "#65a765", "highlight" = "#65a765"),
                               color_mod_coverage = c("background" = "#FFD580", "border" = "#E49B0F", "highlight" = "#E49B0F"),
                               moderate_coverage_range = c(0.2, 0.8),
-                              print_isolated_foo = TRUE,
+                              print_isolated_foo = FALSE,
                               show_in_shiny = FALSE,
                               network_title = "Function Network",
                               scale_node_size_by_degree = TRUE) {
@@ -524,7 +524,6 @@ plotNetwork <- function(df_edges,
   )
 
   if (shiny::isTruthy(scale_node_size_by_degree)) {
-    print("scale by degree")
 
     # don't let igraph warn about replacing missing values
     df_edges <- replace(df_edges, is.na(df_edges), "NA")

--- a/man/visualise_project.Rd
+++ b/man/visualise_project.Rd
@@ -16,7 +16,7 @@ visualise_project(
   color_mod_coverage = c(background = "#FFD580", border = "#E49B0F", highlight =
     "#E49B0F"),
   moderate_coverage_range = c(0.2, 0.8),
-  print_isolated_foo = TRUE,
+  print_isolated_foo = FALSE,
   show_in_shiny = FALSE,
   network_title = "Function Network",
   scale_node_size_by_degree = TRUE
@@ -43,7 +43,7 @@ visualise_project(
 
 \item{moderate_coverage_range}{vector of two values giving range defined as moderate coverage.}
 
-\item{print_isolated_foo}{Print the isolated functions to the console.}
+\item{print_isolated_foo}{Print the isolated functions to the console (default false)}
 
 \item{show_in_shiny}{logical scalar indicating whether to prepare/deploy the
 network using a built in shiny app. Default is \code{FALSE}.}


### PR DESCRIPTION
- adding function call to clipboard so that the user doesn't have to copy-paste.
- changing default to NOT print isolated functions (as takes up space on console).
- minor edit to cat for the function call (adding line above).