### PR TITLE
Add additional check to check_trans_prob

### DIFF
--- a/R/check_trans_probs.R
+++ b/R/check_trans_probs.R
@@ -2,7 +2,8 @@
 #'
 #' This function checks the properties of a transition probability matrix conform to
 #' standard expectations. That it is: symmetric, numeric, values are between 0
-#' and 1 with all rows summing to 1.
+#' and 1 with all rows summing to 1. If a dead state is provided, it checks that the dead
+#' state -> dead state probability is 1.
 #'
 #' @param m_P The transition probability matrix to be checked.
 #' @param confirm_ok if OK, return a message confirming all checks passed.
@@ -266,6 +267,8 @@ check_dead_state_rows <- function(a_P, dead_state = NULL, stop_if_not = F) {
 #' This function checks the properties of a transition probability array with
 #' 2 or three dimensions conform to standard expectations. That it is that each slice is:
 #' symmetric, numeric, values are between 0 and 1 with all rows summing to 1.
+#' If a dead state is provided, it checks that the dead state -> dead state probability
+#' in each slice is equal to 1.
 #'
 #' @param a_P The transition probability array to be checked.
 #' @param stop_if_not return error messages. The default (F) returns warnings.

--- a/man/check_trans_prob_array.Rd
+++ b/man/check_trans_prob_array.Rd
@@ -4,10 +4,12 @@
 \alias{check_trans_prob_array}
 \title{Check Transition Probability Array}
 \usage{
-check_trans_prob_array(a_P, stop_if_not = F)
+check_trans_prob_array(a_P, dead_state = NULL, stop_if_not = F)
 }
 \arguments{
 \item{a_P}{The transition probability array to be checked.}
+
+\item{dead_state}{character vector length 1 denoting dead state (e.g. "D")}
 
 \item{stop_if_not}{return error messages. The default (F) returns warnings.}
 }
@@ -18,6 +20,8 @@ A message indicating whether the array passed all the checks or a warning/error 
 This function checks the properties of a transition probability array with
 2 or three dimensions conform to standard expectations. That it is that each slice is:
 symmetric, numeric, values are between 0 and 1 with all rows summing to 1.
+If a dead state is provided, it checks that the dead state -> dead state probability
+in each slice is equal to 1.
 }
 \examples{
 \dontrun{

--- a/man/check_trans_prob_mat.Rd
+++ b/man/check_trans_prob_mat.Rd
@@ -4,10 +4,12 @@
 \alias{check_trans_prob_mat}
 \title{Check Transition Probability Matrix}
 \usage{
-check_trans_prob_mat(m_P, confirm_ok = F, stop_if_not = F)
+check_trans_prob_mat(m_P, dead_state = NULL, confirm_ok = F, stop_if_not = F)
 }
 \arguments{
 \item{m_P}{The transition probability matrix to be checked.}
+
+\item{dead_state}{character vector length 1 denoting dead state (e.g. "D")}
 
 \item{confirm_ok}{if OK, return a message confirming all checks passed.}
 
@@ -19,7 +21,8 @@ A message indicating whether the matrix passed all the checks or a warning/error
 \description{
 This function checks the properties of a transition probability matrix conform to
 standard expectations. That it is: symmetric, numeric, values are between 0
-and 1 with all rows summing to 1.
+and 1 with all rows summing to 1. If a dead state is provided, it checks that the dead
+state -> dead state probability is 1.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Adds checks to check_trans_prob_mat and check_trans_prob_array to ensure death state -> death state transition probability is always equal to 1, if the user provides a dead_state argument (string, name of the dead state).

Returns an informative warning/error message if the check fails.

Adds tests to show that invalid death state -> death state probability values throws the new warning message.