### PR TITLE
Fix bug in environments for LLM from visualiser

### DIFF
--- a/R/project_visualiser.R
+++ b/R/project_visualiser.R
@@ -170,7 +170,7 @@ load_functions_into_env <- function(path, env) {
   for (file in files) {
     print(file)
     source_funcs(file, env = env)
-    env
+    print(env)
   }
 }
 

--- a/R/project_visualiser.R
+++ b/R/project_visualiser.R
@@ -988,6 +988,7 @@ define_app_ui <- function(network_title) {
 #' Create Shiny app server logic
 #'
 #' @inheritParams run_shiny_app
+#' @param foo_path path to the function folder
 #'
 #' @return Shiny app server logic
 define_app_server <- function(network_object, project_path, foo_path) {
@@ -1244,6 +1245,7 @@ define_app_server <- function(network_object, project_path, foo_path) {
 #' @param network_object visNetwork object to be displayed in the shiny app
 #' @param network_title Title to be displayed in hte app above the title
 #' @param project_path Path to the project directory
+#' @param foo_path Path to the function folder
 #'
 #' @return A shiny app
 #'

--- a/R/summarise_function_with_LLM.R
+++ b/R/summarise_function_with_LLM.R
@@ -10,19 +10,17 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' summarise_function_with_LLM("calculate_costs")
+# summarise_function_with_LLM(foo_name = "get_active_functions",
+#                             envir = rlang::ns_env("assertHE"))
 #' }
 #'
 summarise_function_with_LLM <- function(foo_name,
                                         llm_api_url = Sys.getenv("LLM_API_URL"),
-                                        llm_api_key = Sys.getenv("LLM_API_KEY")){
+                                        llm_api_key = Sys.getenv("LLM_API_KEY"),
+                                        envir = environment()){
 
-
-  print("just before get_function_data")
   # get the function data list (function arguments and body)
-  l_foo_data <- get_function_data(foo_name)
-  print("just after get_function_data")
-
+  l_foo_data <- get_function_data(foo_name, envir = envir)
 
   # API request created and sent
   response <-
@@ -60,10 +58,15 @@ summarise_function_with_LLM <- function(foo_name,
 #' \dontrun{
 #' get_function_data(foo_name = "create_Markov_trace")
 #' }
-get_function_data <- function(foo_name) {
+get_function_data <- function(foo_name, envir = environment()) {
+
   # get data on arguments and body
-  foo_arguments <- methods::formalArgs(def = foo_name)
-  foo_body      <- base::body(foo_name)
+  foo_arguments <- names(formals(foo_name, envir = envir))
+  #foo_body      <- base::body(foo_name)
+  fun <- get(foo_name, mode = "function", envir = envir)
+  foo_body <- .Internal(body(fun))
+
+
   descriptors   <- tryCatch({
     get_roxygen_description_from_foo(foo_name = foo_name)
   }, error = function(e)

--- a/R/summarise_function_with_LLM.R
+++ b/R/summarise_function_with_LLM.R
@@ -4,14 +4,15 @@
 #'
 #' @inheritParams create_prompt
 #' @inheritParams summarise_function_from_arguments_and_body
+#' @param envir The environment in which to look for the function.
 #'
 #' @return A character string with a summary of the function based on its arguments and body.
 #'
 #' @export
 #' @examples
 #' \dontrun{
-# summarise_function_with_LLM(foo_name = "get_active_functions",
-#                             envir = rlang::ns_env("assertHE"))
+#' summarise_function_with_LLM(foo_name = "get_active_functions",
+#'                             envir = rlang::ns_env("assertHE"))
 #' }
 #'
 summarise_function_with_LLM <- function(foo_name,
@@ -51,6 +52,7 @@ summarise_function_with_LLM <- function(foo_name,
 #' This function retrieves data about the arguments and body of a specified function.
 #'
 #' @param foo_name The name of the function to retrieve data from.
+#' @param envir The environment in which to look for the function.
 #' @return A list with elements for 'arguments' and 'body' of the specified function.
 #' @export
 #' @importFrom methods formalArgs
@@ -64,7 +66,7 @@ get_function_data <- function(foo_name, envir = environment()) {
   foo_arguments <- names(formals(foo_name, envir = envir))
   #foo_body      <- base::body(foo_name)
   fun <- get(foo_name, mode = "function", envir = envir)
-  foo_body <- .Internal(body(fun))
+  foo_body <- body(fun)
 
 
   descriptors   <- tryCatch({

--- a/R/summarise_function_with_LLM.R
+++ b/R/summarise_function_with_LLM.R
@@ -16,8 +16,13 @@
 summarise_function_with_LLM <- function(foo_name,
                                         llm_api_url = Sys.getenv("LLM_API_URL"),
                                         llm_api_key = Sys.getenv("LLM_API_KEY")){
+
+
+  print("just before get_function_data")
   # get the function data list (function arguments and body)
   l_foo_data <- get_function_data(foo_name)
+  print("just after get_function_data")
+
 
   # API request created and sent
   response <-

--- a/man/define_app_server.Rd
+++ b/man/define_app_server.Rd
@@ -4,12 +4,14 @@
 \alias{define_app_server}
 \title{Create Shiny app server logic}
 \usage{
-define_app_server(network_object, project_path)
+define_app_server(network_object, project_path, foo_path)
 }
 \arguments{
 \item{network_object}{visNetwork object to be displayed in the shiny app}
 
 \item{project_path}{Path to the project directory}
+
+\item{foo_path}{path to the function folder}
 }
 \value{
 Shiny app server logic

--- a/man/get_function_data.Rd
+++ b/man/get_function_data.Rd
@@ -4,10 +4,12 @@
 \alias{get_function_data}
 \title{Retrieve Function data to a list}
 \usage{
-get_function_data(foo_name)
+get_function_data(foo_name, envir = environment())
 }
 \arguments{
 \item{foo_name}{The name of the function to retrieve data from.}
+
+\item{envir}{The environment in which to look for the function.}
 }
 \value{
 A list with elements for 'arguments' and 'body' of the specified function.

--- a/man/run_shiny_app.Rd
+++ b/man/run_shiny_app.Rd
@@ -9,7 +9,8 @@ run_shiny_app(
   serverFunction = define_app_server,
   network_object,
   network_title = "Function Network",
-  project_path
+  project_path,
+  foo_path
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ run_shiny_app(
 \item{network_title}{Title to be displayed in hte app above the title}
 
 \item{project_path}{Path to the project directory}
+
+\item{foo_path}{Path to the function folder}
 }
 \value{
 A shiny app

--- a/man/summarise_function_with_LLM.Rd
+++ b/man/summarise_function_with_LLM.Rd
@@ -7,7 +7,8 @@
 summarise_function_with_LLM(
   foo_name,
   llm_api_url = Sys.getenv("LLM_API_URL"),
-  llm_api_key = Sys.getenv("LLM_API_KEY")
+  llm_api_key = Sys.getenv("LLM_API_KEY"),
+  envir = environment()
 )
 }
 \arguments{
@@ -16,6 +17,8 @@ summarise_function_with_LLM(
 \item{llm_api_url}{url to the API for the LLM}
 
 \item{llm_api_key}{key for the API for the LLM}
+
+\item{envir}{The environment in which to look for the function.}
 }
 \value{
 A character string with a summary of the function based on its arguments and body.
@@ -25,7 +28,8 @@ This function summarizes another function using a Language Model.
 }
 \examples{
 \dontrun{
-summarise_function_with_LLM("calculate_costs")
+summarise_function_with_LLM(foo_name = "get_active_functions",
+                            envir = rlang::ns_env("assertHE"))
 }
 
 }

--- a/tests/testthat/example_external_function/R/external_dependency.R
+++ b/tests/testthat/example_external_function/R/external_dependency.R
@@ -1,0 +1,18 @@
+external_dependency_EXPLICIT <- function(mat){
+
+  matrixStats::colMins(mat)
+
+}
+
+
+# LIBARY NON EXPLICIT CALL
+
+library(matrixStats)
+external_dependency_NON_explicit <- function(mat){
+
+  colMins(mat)
+
+}
+
+
+#external_dependency(mat = matrix(1:9, nrow = 3))

--- a/tests/testthat/example_project/R/utils.R
+++ b/tests/testthat/example_project/R/utils.R
@@ -19,7 +19,7 @@ utility_example2 <- function(){
 # Bare code - not a function
 x = 15
 if(x == 20) {
-  message("impossible")
+  x <- "impossible"
 } else {
-  message("Hello World")
+  x <- "Hello World"
 }

--- a/tests/testthat/test-project_visualiser.R
+++ b/tests/testthat/test-project_visualiser.R
@@ -11,7 +11,8 @@ test_that("test that nothing blows up with visualiser run ", {
       project_path = project_path,
       foo_path = "R",
       test_path = "tests/testthat",
-      run_coverage = T)
+      run_coverage = F,
+      show_in_shiny = T)
 
   })
 


### PR DESCRIPTION
There was a bug in the visualiser which meant that:
- a recent PR caused the functions to be loaded to a separate environment (good practice)
- the `get` function looking up characteristics of the function was not looking in that environment.

I've now changed the code so that:
- within the visualiser the functions are loaded to a seperate environment 
- the functions are `get` from that environment when the LLM summary is run.