### PR TITLE
Add doi for assertHE reference paper to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Description: Designed to help health economic modellers when building and review
     The visualisation functions allow users to more easily review the network of functions 
     in a project, and get lay summaries of them. The asserts included are intended to check for common errors,
     thereby freeing up time for modellers to focus on tests specific to the individual model in development or review.
+    For more details see Smith and colleagues (2024)<doi:10.12688/wellcomeopenres.23180.1>.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
I've added the doi number to the references in the requested format:

> If there are references describing the methods in your package, please add these in the description field of your DESCRIPTION file in the form authors (year) doi:... authors (year, ISBN:...) or if those are not available: [https:...](https://github.com/dark-peak-analytics/assertHE/issues/...) with no space after 'doi:', 'https:' and angle brackets for auto-linking. (If you want to add a title as well please put it in quotes: "Title") For more details https://contributor.r-project.org/cran-cookbook/description_issues.html#references

I used this format: _doi:10.12688/wellcomeopenres.23180.1_

(Instead of a hyperlink:  https://doi.org/10.12688/wellcomeopenres.23180.1)