### PR TITLE
Add return value to roxgyen documentation

### DIFF
--- a/R/utils-file.R
+++ b/R/utils-file.R
@@ -175,14 +175,14 @@ source_files <- function( file_regx = ".R",
 
 
 #' @title source_lines
-#' @description Sources specified lines within a single file
+#' @description Sources specified lines within a single file.
 #' # IMPORTANT !!!
-#' sourcing *this* file is a mistake - may result in infinite recursion
-#' @param file = a connection object or a character string path to a file.
-#' @param lines = A vector of integers specifying the lines to be sourced.
-#' @param env the environment in which to source the lines
+#' Sourcing *this* file is a mistake - may result in infinite recursion.
+#' @param file a connection object or a character string path to a file.
+#' @param lines A vector of integers specifying the lines to be sourced.
+#' @param env the environment in which to source the lines.
 #'
-#' @return NULL
+#' @return No return value, called for side effects.
 #'
 #' @export
 #'
@@ -216,13 +216,13 @@ source_lines <- function(file, lines, env = .GlobalEnv){
 }
 
 #' @title source_funcs
-#' @description Sources *only* the functions discovered in an R file
+#' @description Sources *only* the functions discovered in an R file.
 #' # IMPORTANT !!!
-#' sourcing *this* file is a mistake - may result in infinite recursion
-#' @param file = a connection object or a character string path to a file.
-#' @param env the environment in which to source the functions
+#' Sourcing *this* file is a mistake - may result in infinite recursion.
+#' @param file a connection object or a character string path to a file.
+#' @param env the environment in which to source the functions.
 #'
-#' @return NULL
+#' @return No return value, called for side effects.
 #'
 #' @export
 #'

--- a/man/source_funcs.Rd
+++ b/man/source_funcs.Rd
@@ -7,15 +7,18 @@
 source_funcs(file, env = .GlobalEnv)
 }
 \arguments{
-\item{file}{= a connection object or a character string path to a file.}
+\item{file}{a connection object or a character string path to a file.}
 
-\item{env}{the environment in which to source the functions}
+\item{env}{the environment in which to source the functions.}
+}
+\value{
+No return value, called for side effects.
 }
 \description{
-Sources \emph{only} the functions discovered in an R file
+Sources \emph{only} the functions discovered in an R file.
 }
 \section{IMPORTANT !!!}{
-sourcing \emph{this} file is a mistake - may result in infinite recursion
+Sourcing \emph{this} file is a mistake - may result in infinite recursion.
 }
 
 \examples{

--- a/man/source_lines.Rd
+++ b/man/source_lines.Rd
@@ -7,17 +7,20 @@
 source_lines(file, lines, env = .GlobalEnv)
 }
 \arguments{
-\item{file}{= a connection object or a character string path to a file.}
+\item{file}{a connection object or a character string path to a file.}
 
-\item{lines}{= A vector of integers specifying the lines to be sourced.}
+\item{lines}{A vector of integers specifying the lines to be sourced.}
 
-\item{env}{the environment in which to source the lines}
+\item{env}{the environment in which to source the lines.}
+}
+\value{
+No return value, called for side effects.
 }
 \description{
-Sources specified lines within a single file
+Sources specified lines within a single file.
 }
 \section{IMPORTANT !!!}{
-sourcing \emph{this} file is a mistake - may result in infinite recursion
+Sourcing \emph{this} file is a mistake - may result in infinite recursion.
 }
 
 \examples{


### PR DESCRIPTION
Addresses CRAN feedback:

> Please add \value to .Rd files regarding exported methods and explain the functions results in the documentation. Please write about the structure of the output (class) and also what the output means. (If a function does not return a value, please document that too, e.g. \value{No return value, called for side effects} or similar) For more details: https://contributor.r-project.org/cran-cookbook/docs_issues.html#missing-value-tags-in-.rd-files
> 
> Missing Rd-tags:
> source_funcs.Rd: \value
> source_lines.Rd: \value

These functions don't return anything (they source particular lines or functions), and the documentation now explicitly states this.

I've also added periods to the end of sentences, and removed unnecessary `=` signs in the roxygen comments.
