### PR TITLE
Remove roxygen examples for unexported functions

### DIFF
--- a/R/project_visualiser.R
+++ b/R/project_visualiser.R
@@ -138,11 +138,6 @@ visualise_project <- function(project_path,
 #' @param df_edges A data.table with two columns ("from" and "to") representing the dependencies.
 #'
 #' @return A vector of isolated function names.
-#'
-#' @examples
-#' \dontrun{
-#' get_isolated_foo(df_edges = data.frame(from = c("a", "b", "c", "d"), to = c("b", "c", NA, NA)))
-#' }
 get_isolated_foo <- function(df_edges){
   # get all unique functions
   v_functions <- unique(c(df_edges$from, df_edges$to))
@@ -221,17 +216,6 @@ identify_dependencies <- function(v_unique_foo, pkg_env = environment()) {
 #'
 #' Note: This function may potentially miss calls if they are in attributes of the closure. For example
 #' when function is defined within another function, capturing the environment of the outer function.
-#'
-#' @examples
-#' \dontrun{
-#' # Identify functions called by a specific function
-#' .called_by(
-#' fname = "my_function",
-#' all_functions = c("function1", "function2", "function3"),
-#' pkg_env = environment())
-#' }
-#'
-#'
 .called_by <- function(fname,
                        all_functions,
                        pkg_env){
@@ -309,13 +293,6 @@ identify_dependencies <- function(v_unique_foo, pkg_env = environment()) {
 #' they can no longer be listed, filtering out atomic values in the process.
 #'
 #' If `x` is not listable (e.g. a function), it is deparsed into a character string.
-#'
-#' @examples
-#' \dontrun{
-#' # Parse a simple expression
-#' tmp <- dplyr::across
-#' .parse_function(tmp)
-#' }
 .parse_function <- function (x) {
   # If expression x is not an atomic value or symbol (i.e., name of object) or
   # an environment pointer then we can break x up into list of components
@@ -660,19 +637,6 @@ processNodes <- function(df_edges,
 #' @return A character scalar
 #'
 #' @importFrom here here
-#'
-#' @examples
-#' \dontrun{
-#' cleaned_file_path <- get_function_path(
-#'  file_location = "tests/testthat/example_project/R/calculate_QALYs.R#L41"
-#' )
-#' cleaned_file_path <- get_function_path(
-#'  file_location = c(
-#'    "tests/testthat/example_project/R/calculate_QALYs.R#L41",
-#'    "tests/testthat/example_project/R/calculate_QALYs.R#L49"
-#'  )
-#' )
-#' }
 get_function_path <- function(file_location, project_path) {
 
   get_function_path <- gsub("#.*", "", file_location)
@@ -691,19 +655,6 @@ get_function_path <- function(file_location, project_path) {
 #' @param file_location Character scalar specifying the path of a file.
 #'
 #' @return A numeric scalar
-#'
-#' @examples
-#' \dontrun{
-#' cleaned_function_line <- get_function_line(
-#'  file_location = "tests/testthat/example_project/R/calculate_QALYs.R:L41"
-#' )
-#' cleaned_function_line <- get_function_line(
-#'  file_location = c(
-#'    "tests/testthat/example_project/R/calculate_QALYs.R#L41",
-#'    "tests/testthat/example_project/R/calculate_QALYs.R#L49"
-#'  )
-#' )
-#' }
 get_function_line <- function(file_location) {
 
   function_line <- gsub(".*#L", "", file_location)
@@ -1250,18 +1201,6 @@ define_app_server <- function(network_object, project_path, foo_path) {
 #' @return A shiny app
 #'
 #' @importFrom rstudioapi navigateToFile
-#'
-#' @examples
-#' \dontrun{
-#' network_object <- visualise_project(
-#'     project_path = "tests/testthat/example_project",
-#'     foo_path = "R",
-#'     test_path = "tests/testthat",
-#'     run_coverage = TRUE
-#'  )
-#'
-#'  run_shiny_app(network_object = network_object)
-#' }
 run_shiny_app <- function(
     uiFunction = define_app_ui,
     serverFunction = define_app_server,

--- a/R/summarise_function_with_LLM.R
+++ b/R/summarise_function_with_LLM.R
@@ -242,11 +242,6 @@ return_message <- function(API_response,
 #'
 #' @return text containing description
 #' @importFrom roxygen2 parse_file
-#' @examples
-#' \dontrun{
-#' source_files(path = "tests/testthat/example_project/R", keep_source = TRUE)
-#' get_roxygen_description_from_foo("calculate_costs")
-#' }
 get_roxygen_description_from_foo <- function(foo_name) {
   # get the name of the file containing the function
   filename <- utils::getSrcFilename(x = eval(parse(text = foo_name)),

--- a/man/dot-called_by.Rd
+++ b/man/dot-called_by.Rd
@@ -30,14 +30,3 @@ function and "to" as NA.
 Note: This function may potentially miss calls if they are in attributes of the closure. For example
 when function is defined within another function, capturing the environment of the outer function.
 }
-\examples{
-\dontrun{
-# Identify functions called by a specific function
-.called_by(
-fname = "my_function",
-all_functions = c("function1", "function2", "function3"),
-pkg_env = environment())
-}
-
-
-}

--- a/man/dot-parse_function.Rd
+++ b/man/dot-parse_function.Rd
@@ -25,10 +25,3 @@ they can no longer be listed, filtering out atomic values in the process.
 
 If \code{x} is not listable (e.g. a function), it is deparsed into a character string.
 }
-\examples{
-\dontrun{
-# Parse a simple expression
-tmp <- dplyr::across
-.parse_function(tmp)
-}
-}

--- a/man/get_function_line.Rd
+++ b/man/get_function_line.Rd
@@ -15,16 +15,3 @@ A numeric scalar
 \description{
 Extract function line in file path
 }
-\examples{
-\dontrun{
-cleaned_function_line <- get_function_line(
- file_location = "tests/testthat/example_project/R/calculate_QALYs.R:L41"
-)
-cleaned_function_line <- get_function_line(
- file_location = c(
-   "tests/testthat/example_project/R/calculate_QALYs.R#L41",
-   "tests/testthat/example_project/R/calculate_QALYs.R#L49"
- )
-)
-}
-}

--- a/man/get_function_path.Rd
+++ b/man/get_function_path.Rd
@@ -17,16 +17,3 @@ A character scalar
 \description{
 Remove artefacts from file path
 }
-\examples{
-\dontrun{
-cleaned_file_path <- get_function_path(
- file_location = "tests/testthat/example_project/R/calculate_QALYs.R#L41"
-)
-cleaned_file_path <- get_function_path(
- file_location = c(
-   "tests/testthat/example_project/R/calculate_QALYs.R#L41",
-   "tests/testthat/example_project/R/calculate_QALYs.R#L49"
- )
-)
-}
-}

--- a/man/get_isolated_foo.Rd
+++ b/man/get_isolated_foo.Rd
@@ -15,8 +15,3 @@ A vector of isolated function names.
 \description{
 Get Isolated Functions
 }
-\examples{
-\dontrun{
-get_isolated_foo(df_edges = data.frame(from = c("a", "b", "c", "d"), to = c("b", "c", NA, NA)))
-}
-}

--- a/man/get_roxygen_description_from_foo.Rd
+++ b/man/get_roxygen_description_from_foo.Rd
@@ -15,9 +15,3 @@ text containing description
 \description{
 Get roxygen title and description from function
 }
-\examples{
-\dontrun{
-source_files(path = "tests/testthat/example_project/R", keep_source = TRUE)
-get_roxygen_description_from_foo("calculate_costs")
-}
-}

--- a/man/run_shiny_app.Rd
+++ b/man/run_shiny_app.Rd
@@ -32,15 +32,3 @@ A shiny app
 \description{
 Run a Shiny app to host a network visualization
 }
-\examples{
-\dontrun{
-network_object <- visualise_project(
-    project_path = "tests/testthat/example_project",
-    foo_path = "R",
-    test_path = "tests/testthat",
-    run_coverage = TRUE
- )
-
- run_shiny_app(network_object = network_object)
-}
-}


### PR DESCRIPTION
Addresses CRAN feedback:

> You have examples for unexported functions. Please either omit these examples or export these functions. Examples for unexported function
> .called_by() in:
> dot-called_by.Rd
> .parse_function() in:
> dot-parse_function.Rd
> get_function_line() in:
> get_function_line.Rd
> get_function_path() in:
> get_function_path.Rd
> get_isolated_foo() in:
> get_isolated_foo.Rd
> get_roxygen_description_from_foo() in:
> get_roxygen_description_from_foo.Rd
> run_shiny_app() in:
> run_shiny_app.Rd