### PR TITLE
Fix un-executable example code for several exported functions

### DIFF
--- a/R/cheers_checker.R
+++ b/R/cheers_checker.R
@@ -176,7 +176,7 @@ find_function_definitions <- function(filename){
 #' \dontrun{
 #' # Skip listed files "somefile.R", and "another_file.R"
 #' find_folder_function_definitions(
-#' foo_folder = "tests/testthat/example_project"
+#' foo_folder = "tests/testthat/example_project",
 #' f_excl = "\\b(somefile\\.R|another_file\\.R)\\b"
 #' )
 #' }

--- a/R/utils-file.R
+++ b/R/utils-file.R
@@ -80,14 +80,12 @@ locate_funcs <-  function(file) {
 #'
 #'
 #' @examples
-#' \dontrun{
 #' find_files(file_regx = ".*",  ## any file name
 #'  path = ".*",   # the current directory and all subdirectories
 #'  recursive = FALSE,  # don't recurse
 #'  exclude_files = ".*utility.*", # exclude "utility" anywhere in basename
-#'  exclude_dirs = "\/tmp\/"  # exclude any directory named "tmp", or subdirs
+#'  exclude_dirs = "\\<tmp\\>|/tmp/|/tmp\\>|\\<tmp/"  # exclude any directory named "tmp", or subdirs
 #'  )
-#' }
 #'
 find_files <- function( file_regx = ".R",
                           path = ".",
@@ -146,7 +144,7 @@ find_files <- function( file_regx = ".R",
 #'  path = ".*",   # the current directory and all subdirectories
 #'  recursive = FALSE,  # don't recurse
 #'  exclude_files = ".*utility.*", # exclude "utility" anywhere in basename
-#'  exclude_dirs = "\/tmp\/"  # exclude any directory named "tmp", or subdirs
+#'  exclude_dirs = "\\<tmp\\>|/tmp/|/tmp\\>|\\<tmp/"  # exclude any directory named "tmp", or subdirs
 #'  )
 #' }
 #'

--- a/man/find_files.Rd
+++ b/man/find_files.Rd
@@ -31,13 +31,11 @@ Find files based upon regular expression searching
 IMPORTANT - a Directory is NOT a file. (for most instances of file systems)
 }
 \examples{
-\dontrun{
 find_files(file_regx = ".*",  ## any file name
  path = ".*",   # the current directory and all subdirectories
  recursive = FALSE,  # don't recurse
  exclude_files = ".*utility.*", # exclude "utility" anywhere in basename
- exclude_dirs = "\/tmp\/"  # exclude any directory named "tmp", or subdirs
+ exclude_dirs = "\\\\<tmp\\\\>|/tmp/|/tmp\\\\>|\\\\<tmp/"  # exclude any directory named "tmp", or subdirs
  )
-}
 
 }

--- a/man/find_folder_function_definitions.Rd
+++ b/man/find_folder_function_definitions.Rd
@@ -27,7 +27,7 @@ Applies find_function_definitions to each file in a folder and aggregate results
 \dontrun{
 # Skip listed files "somefile.R", and "another_file.R"
 find_folder_function_definitions(
-foo_folder = "tests/testthat/example_project"
+foo_folder = "tests/testthat/example_project",
 f_excl = "\\\\b(somefile\\\\.R|another_file\\\\.R)\\\\b"
 )
 }

--- a/man/source_files.Rd
+++ b/man/source_files.Rd
@@ -48,7 +48,7 @@ source_files(file_regx = ".*",  ## any file name
  path = ".*",   # the current directory and all subdirectories
  recursive = FALSE,  # don't recurse
  exclude_files = ".*utility.*", # exclude "utility" anywhere in basename
- exclude_dirs = "\/tmp\/"  # exclude any directory named "tmp", or subdirs
+ exclude_dirs = "\\\\<tmp\\\\>|/tmp/|/tmp\\\\>|\\\\<tmp/"  # exclude any directory named "tmp", or subdirs
  )
 }
 


### PR DESCRIPTION
Addresses CRAN submission feedback:

> We see: Warning: Unexecutable code in man/find_files.Rd: NA Warning: Unexecutable code in man/find_folder_function_definitions.Rd: f_excl: Warning: Unexecutable code in man/source_files.Rd: NA: Please make sure that the syntax of your functions is correct. I think you forgot to add some commas between your function arguments.

* One example was missing a comma between function arguments.
* The other two examples were using `\` in regular expressions -- these need to be specified as `\\` because `\` is the escape character in R strings.