### PR TITLE
Remove unnecessary \dontrun{} tags from examples

### DIFF
--- a/R/check_init.R
+++ b/R/check_init.R
@@ -12,16 +12,15 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' x <- setNames(object = c(0.2, 0.3, 0.4, 0.1), nm = letters[1:4])
-#' check_init(x) # Should issue warnings for values outside 0-1 and the sum not equal to 1
+#' check_init(x) # x is a valid input, no warnings issued
 #'
-#' x <- c(0.2, 0.3, 0.4, 0.1) # Missing names
+#' x <- setNames(c(0.2, 0.3, 0.4, 0.1), nm = c("H", NA, "NA", "D"))
 #' check_init(x) # Should issue a warning about missing names
 #'
-#' x <- c(-2, 0.3, 0.4, 0.1) # Missing names
+#' x <- c(-2, 0.3, 0.4, 0.1)
 #' check_init(x) # Should issue a warning about a value below 0 and about not summing to 1
-#' }
+#'
 check_init <- function(x) {
   # Check that all values of x are between 0 and 1
   if (any(x < 0) || any(x > 1) || any(is.na(x))) {

--- a/R/check_markov_trace.R
+++ b/R/check_markov_trace.R
@@ -24,13 +24,11 @@
 #' m_TR[, "D"] <- 1 - m_TR[, "H"] - m_TR[, "S"]
 #' check_markov_trace(m_TR = m_TR, dead_state = "D", confirm_ok = TRUE)
 #'
-#'\dontrun{
 #'# the following results in an error because the trace has infeasible values
 #' m_TR[10, "D"] <- 0
 #' m_TR[9, "S"] <- 1
 #' check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE)
 #'
-#'}
 #' @return A message indicating whether the matrix passed all the checks or an error message if any check failed.
 #'
 #' @import assertthat

--- a/R/check_markov_trace.R
+++ b/R/check_markov_trace.R
@@ -27,7 +27,7 @@
 #'# the following results in an error because the trace has infeasible values
 #' m_TR[10, "D"] <- 0
 #' m_TR[9, "S"] <- 1
-#' check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE)
+#' try(check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE))
 #'
 #' @return A message indicating whether the matrix passed all the checks or an error message if any check failed.
 #'

--- a/R/check_trans_probs.R
+++ b/R/check_trans_probs.R
@@ -22,11 +22,9 @@
 #' diag(m_P) <- (1 - rowSums(m_P))
 #' check_trans_prob_mat(m_P)
 #'
-#' \dontrun{
 #' # introduce error
 #' m_P["H", "S"] <- 0.2
-#' check_trans_prob_mat(m_P,  confirm_ok = TRUE, stop_if_not = TRUE)
-#' }
+#' try(check_trans_prob_mat(m_P,  confirm_ok = TRUE, stop_if_not = TRUE))
 #'
 #' @return A message indicating whether the matrix passed all the checks or a warning/error message if any check failed.
 #'
@@ -276,7 +274,6 @@ check_dead_state_rows <- function(a_P, dead_state = NULL, stop_if_not = FALSE) {
 #' @param dead_state character vector length 1 denoting dead state (e.g. "D")
 #'
 #' @examples
-#' \dontrun{
 #' v_hs_names <- c("H", "S", "D")
 #' n_hs <- length(v_hs_names)
 #' a_P <- array(
@@ -297,9 +294,7 @@ check_dead_state_rows <- function(a_P, dead_state = NULL, stop_if_not = FALSE) {
 #' # introduce error
 #' a_P["H", "S", 1:10] <- 0
 #'
-#' check_trans_prob_array(a_P = a_P, stop_if_not = FALSE)
-#'
-#' }
+#' try(check_trans_prob_array(a_P = a_P, stop_if_not = FALSE))
 #'
 #' @return A message indicating whether the array passed all the checks or a warning/error message if any check failed.
 #'

--- a/R/cheers_checker.R
+++ b/R/cheers_checker.R
@@ -40,12 +40,10 @@ find_next_vector_element <- function(value, vector, LTE=FALSE) {
 #' @return The previous element of the vector before the value
 #' @export
 #' @examples
-#' \dontrun{
 #' find_previous_vector_element(value = 5, vector = 1:10)
 #' find_previous_vector_element(value = 5, vector = 6:10)
 #' find_previous_vector_element(value = 5, vector = 5:10, LTE = FALSE)
 #' find_previous_vector_element(value = 5, vector = 5:10, LTE = TRUE)
-#' }
 #'
 find_previous_vector_element <- function(value, vector, LTE=FALSE){
 

--- a/R/summarise_function_with_LLM.R
+++ b/R/summarise_function_with_LLM.R
@@ -179,14 +179,13 @@ summarise_function_from_arguments_and_body <- function(foo_name,
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' create_prompt(
 #' foo_arguments = LETTERS[1:3],
 #' foo_body = "D <- A+B+C; return(D)",
 #' foo_name = "calculate_QALYs",
 #' foo_desc = "This function calcs QALYs",
 #' foo_title = "Calculate the QALYs")
-#' }
+#'
 create_prompt <- function(foo_arguments,
                           foo_body,
                           foo_name,
@@ -276,11 +275,10 @@ get_roxygen_description_from_foo <- function(foo_name) {
 #' @return A list containing the title and description.
 #' @export
 #' @examples
-#' \dontrun{
 #' parsed_list <- list(list(tag = "title", val = "Sample Title"),
 #'                      list(tag = "description", val = "This is a sample description."))
 #' get_roxygen_description(parsed_list)
-#' }
+#'
 get_roxygen_description <- function(parsed_list) {
   desc_index <- sapply(
     X = parsed_list,

--- a/man/check_init.Rd
+++ b/man/check_init.Rd
@@ -19,14 +19,13 @@ within the range 0 to 1 inclusive, the sum of values being equal to 1, no duplic
 and all elements having names.
 }
 \examples{
-\dontrun{
 x <- setNames(object = c(0.2, 0.3, 0.4, 0.1), nm = letters[1:4])
-check_init(x) # Should issue warnings for values outside 0-1 and the sum not equal to 1
+check_init(x) # x is a valid input, no warnings issued
 
-x <- c(0.2, 0.3, 0.4, 0.1) # Missing names
+x <- setNames(c(0.2, 0.3, 0.4, 0.1), nm = c("H", NA, "NA", "D"))
 check_init(x) # Should issue a warning about missing names
 
-x <- c(-2, 0.3, 0.4, 0.1) # Missing names
+x <- c(-2, 0.3, 0.4, 0.1)
 check_init(x) # Should issue a warning about a value below 0 and about not summing to 1
-}
+
 }

--- a/man/check_markov_trace.Rd
+++ b/man/check_markov_trace.Rd
@@ -43,11 +43,9 @@ m_TR[, "S"] <- seq(0, 0.5, length.out = n_t)
 m_TR[, "D"] <- 1 - m_TR[, "H"] - m_TR[, "S"]
 check_markov_trace(m_TR = m_TR, dead_state = "D", confirm_ok = TRUE)
 
-\dontrun{
 # the following results in an error because the trace has infeasible values
 m_TR[10, "D"] <- 0
 m_TR[9, "S"] <- 1
 check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE)
 
-}
 }

--- a/man/check_markov_trace.Rd
+++ b/man/check_markov_trace.Rd
@@ -46,6 +46,6 @@ check_markov_trace(m_TR = m_TR, dead_state = "D", confirm_ok = TRUE)
 # the following results in an error because the trace has infeasible values
 m_TR[10, "D"] <- 0
 m_TR[9, "S"] <- 1
-check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE)
+try(check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE))
 
 }

--- a/man/check_trans_prob_array.Rd
+++ b/man/check_trans_prob_array.Rd
@@ -24,7 +24,6 @@ If a dead state is provided, it checks that the dead state -> dead state probabi
 in each slice is equal to 1.
 }
 \examples{
-\dontrun{
 v_hs_names <- c("H", "S", "D")
 n_hs <- length(v_hs_names)
 a_P <- array(
@@ -45,8 +44,6 @@ check_trans_prob_array(a_P = a_P, stop_if_not = FALSE)
 # introduce error
 a_P["H", "S", 1:10] <- 0
 
-check_trans_prob_array(a_P = a_P, stop_if_not = FALSE)
-
-}
+try(check_trans_prob_array(a_P = a_P, stop_if_not = FALSE))
 
 }

--- a/man/check_trans_prob_mat.Rd
+++ b/man/check_trans_prob_mat.Rd
@@ -41,10 +41,8 @@ m_P["S", "H"] <- 0.5
 diag(m_P) <- (1 - rowSums(m_P))
 check_trans_prob_mat(m_P)
 
-\dontrun{
 # introduce error
 m_P["H", "S"] <- 0.2
-check_trans_prob_mat(m_P,  confirm_ok = TRUE, stop_if_not = TRUE)
-}
+try(check_trans_prob_mat(m_P,  confirm_ok = TRUE, stop_if_not = TRUE))
 
 }

--- a/man/create_prompt.Rd
+++ b/man/create_prompt.Rd
@@ -25,12 +25,11 @@ Uses the function arguments and function body as inputs to create a prompt
 for the LLM.
 }
 \examples{
-\dontrun{
 create_prompt(
 foo_arguments = LETTERS[1:3],
 foo_body = "D <- A+B+C; return(D)",
 foo_name = "calculate_QALYs",
 foo_desc = "This function calcs QALYs",
 foo_title = "Calculate the QALYs")
-}
+
 }

--- a/man/find_previous_vector_element.Rd
+++ b/man/find_previous_vector_element.Rd
@@ -20,11 +20,9 @@ The previous element of the vector before the value
 Find the previous element of the vector before a value
 }
 \examples{
-\dontrun{
 find_previous_vector_element(value = 5, vector = 1:10)
 find_previous_vector_element(value = 5, vector = 6:10)
 find_previous_vector_element(value = 5, vector = 5:10, LTE = FALSE)
 find_previous_vector_element(value = 5, vector = 5:10, LTE = TRUE)
-}
 
 }

--- a/man/get_roxygen_description.Rd
+++ b/man/get_roxygen_description.Rd
@@ -16,9 +16,8 @@ A list containing the title and description.
 This function extracts the title and description from a parsed list.
 }
 \examples{
-\dontrun{
 parsed_list <- list(list(tag = "title", val = "Sample Title"),
                      list(tag = "description", val = "This is a sample description."))
 get_roxygen_description(parsed_list)
-}
+
 }


### PR DESCRIPTION
These examples don't depend on any missing information (e.g. particular files or API keys) and they run quickly.

Addresses CRAN feedback:

> `\dontrun{}` should only be used if the example really cannot be executed (e.g. because of missing additional software, missing API keys, ...) by the user. That's why wrapping examples in `\dontrun{}` adds the comment (`"# Not run:"`) as a warning for the user. Does not seem necessary. Please replace `\dontrun` with `\donttest`. Please unwrap the examples if they are executable in < 5 sec, or replace `dontrun{}` with `\donttest{}`. For more details: https://contributor.r-project.org/cran-cookbook/general_issues.html#structuring-of-examples

There are still some remaining `@examples` that use `\dontrun{}`. These `@examples` call on files, packages, or objects that will not necessary be present/available to the package user. For that reason, I've left these `@examples` as is, but we may want to consider modifying or removing these `@examples`, where appropriate.