### PR TITLE
Use tryCatch rather than try? 

### DIFF
--- a/R/check_markov_trace.R
+++ b/R/check_markov_trace.R
@@ -27,7 +27,14 @@
 #'# the following results in an error because the trace has infeasible values
 #' m_TR[10, "D"] <- 0
 #' m_TR[9, "S"] <- 1
-#' try(check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE))
+#' tryCatch({
+#'   # Code that might cause an error
+#'   check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE)
+#'   },
+#' error = function(e) {
+#'   # Capture and print the error message instead of stopping execution
+#'   message("An error occurred: ", e$message)
+#' })
 #'
 #' @return A message indicating whether the matrix passed all the checks or an error message if any check failed.
 #'

--- a/man/check_markov_trace.Rd
+++ b/man/check_markov_trace.Rd
@@ -46,6 +46,13 @@ check_markov_trace(m_TR = m_TR, dead_state = "D", confirm_ok = TRUE)
 # the following results in an error because the trace has infeasible values
 m_TR[10, "D"] <- 0
 m_TR[9, "S"] <- 1
-try(check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE))
+tryCatch({
+  # Code that might cause an error
+  check_markov_trace(m_TR = m_TR, stop_if_not = TRUE, dead_state = "D", confirm_ok = TRUE)
+  },
+error = function(e) {
+  # Capture and print the error message instead of stopping execution
+  message("An error occurred: ", e$message)
+})
 
 }


### PR DESCRIPTION
I figure it is better to have the `tryCatch` and print the error for the user so they can see it. The `try` approach it could work or not work and the user wouldn't know.

Not sure if this is permitted by CRAN, happy to revert to whatever they want.

