### PR TITLE
Removes `dplyr::location()` issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ rsconnect/
 
 *.docx
 docs
+.DS_Store
+.quarto

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: assertHE
 Title: Visualisation and Verification of Health Economic Decision Models
-Version: 1.0.0.9000
+Version: 1.0.1
 Authors@R: c(
     person("Robert", "Smith", , "rsmith@darkpeakanalytics.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0245-3217")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Designed to help health economic modellers when building and review
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Suggests: 
     testthat (>= 3.0.0),
     colourpicker,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# assertHE (development version)
+# assertHE 1.0.1
+
+* Fixes issue arising from `dplyr` updates. `dplyr` recently removed `dplyr::location()`. `assertHE` referenced a column named `location` but does not note this as a global variable with `utils::globalVariables("location")` which did not cause an issue because `dplyr` was exporting a function with the same name `location()`.
+* Unifies coverage percentage where test location/folder is `NA`.
 
 # assertHE 1.0.0
 

--- a/R/project_visualiser.R
+++ b/R/project_visualiser.R
@@ -642,8 +642,9 @@ processNodes <- function(df_edges,
       unlist(use.names = FALSE) |>
       unique() |>
       stats::na.omit()
-  ) |>
-    dplyr::mutate(label = id)
+  )
+
+  df_nodes[["label"]] <- df_nodes$id
 
   return(df_nodes)
 }

--- a/R/project_visualiser.R
+++ b/R/project_visualiser.R
@@ -468,7 +468,13 @@ plotNetwork <- function(df_edges,
           )
         ),
         "<br><b>Coverage</b>: ",
-        paste0(df_node_info$coverage[index] * 100, "%")
+        paste0(
+          ifelse(
+            test = is.na(df_node_info$coverage[index]),
+            yes = paste0(0, "%"),
+            no = paste0(df_node_info$coverage[index] * 100, "%")
+          )
+        )
       )
     }
   } else {
@@ -485,7 +491,13 @@ plotNetwork <- function(df_edges,
         no = df_node_info$test_location
         ),
       "<br><b>Coverage</b>: ",
-      paste0(df_node_info$coverage * 100, "%")
+      paste0(
+        ifelse(
+          test = is.na(df_node_info$coverage),
+          yes = paste0(0, "%"),
+          no = paste0(df_node_info$coverage * 100, "%")
+        )
+      )
     )
   }
 

--- a/R/test_finder.R
+++ b/R/test_finder.R
@@ -6,7 +6,7 @@
 #' @param foo_strings string vector of function names to search for
 #' @param filter_for_test_that whether to filter for only functions used after the call to test_that. Default FALSE.
 #'
-#' @return a dataframe with the columns 'foo' for function name and 'location' which gives
+#' @return a dataframe with the columns 'foo' for function name and 'test_location' which gives
 #' the file in which the function is called with the line in which the function is called
 #' appended.
 #'
@@ -69,10 +69,10 @@ find_function_calls_in_file <- function(relative_path = NULL,
   if(nrow(df) == 0) return(NULL)
 
   # combine file path & line number in single string
-  df$location <- paste0(relative_path, "#L", df$line)
+  df$test_location <- paste0(relative_path, "#L", df$line)
   df$foo_string  <- df$text
 
-  return(df[, c("foo_string", "location")])
+  return(df[, c("foo_string", "test_location")])
 
 }
 
@@ -85,7 +85,7 @@ find_function_calls_in_file <- function(relative_path = NULL,
 #' @param test_folder folder containing all tests
 #' @inheritParams find_function_calls_in_file
 #'
-#' @return dataframe with two columns. 'foo' contains function names, location
+#' @return dataframe with two columns. 'foo' contains function names, test_location
 #' contains the location of the tests for each function (file and line number).
 #' @export
 #'
@@ -131,8 +131,7 @@ find_function_calls_in_folder <- function(test_folder,
 
   # get summary dataframe
   df_summary <- dplyr::bind_rows(l_foo_test_paths) |>
-                  as.data.frame() |>
-                  dplyr::rename(test_location = location)
+                  as.data.frame()
 
   # ensure all function inputs are included in dataframe of outputs
   df_out <- merge(

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,7 +37,7 @@ We are continuing to work to improve the package and welcome contributions. To g
 
 ## Installation
 
-You can install the CRAN version of assertHE from [CRAN](https://cran.r-project.org/web/packages/assertHE/) with:
+You can install the CRAN version of assertHE from [CRAN](https://CRAN.R-project.org/package=assertHE) with:
 
 ``` r
 install.packages("assertHE")

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ wiki](https://github.com/dark-peak-analytics/assertHE/wiki/assertHE:-an-R-packag
 ## Installation
 
 You can install the CRAN version of assertHE from
-[CRAN](https://cran.r-project.org/web/packages/assertHE/) with:
+[CRAN](https://CRAN.R-project.org/package=assertHE) with:
 
 ``` r
 install.packages("assertHE")

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,9 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+── R CMD check results ──────────────────────────────────────── assertHE 1.0.1 ────
+Duration: 1m 7.5s
 
-* checking for future file timestamps ... NOTE
+❯ checking for future file timestamps ... NOTE
   unable to verify current time
 
-* This is a new release.
-
-## Notes on CRAN incoming checks
-
-* CRAN flagged the script R/cheers_checker.R as adapting the Global Environment or using rm(list = ls()). We cannot identify any that modify the Global Environment or use rm(list = ls()). Are you able to advise?
-
-* CRAN flagged the script R/addin_handler.R which defines the RStudio addin as adapting the Global Environment or using rm(list = ls()). We cannot identify any code that modify the Global Environment or use rm(list=ls()). Are you able to advise?
+0 errors ✔ | 0 warnings ✔ | 1 note ✖

--- a/man/find_function_calls_in_file.Rd
+++ b/man/find_function_calls_in_file.Rd
@@ -18,7 +18,7 @@ find_function_calls_in_file(
 \item{filter_for_test_that}{whether to filter for only functions used after the call to test_that. Default FALSE.}
 }
 \value{
-a dataframe with the columns 'foo' for function name and 'location' which gives
+a dataframe with the columns 'foo' for function name and 'test_location' which gives
 the file in which the function is called with the line in which the function is called
 appended.
 }

--- a/man/find_function_calls_in_folder.Rd
+++ b/man/find_function_calls_in_folder.Rd
@@ -18,7 +18,7 @@ find_function_calls_in_folder(
 \item{filter_for_test_that}{whether to filter for only functions used after the call to test_that. Default FALSE.}
 }
 \value{
-dataframe with two columns. 'foo' contains function names, location
+dataframe with two columns. 'foo' contains function names, test_location
 contains the location of the tests for each function (file and line number).
 }
 \description{

--- a/tests/testthat/test-test_finder.R
+++ b/tests/testthat/test-test_finder.R
@@ -16,7 +16,7 @@ test_that(desc = "Check find_function_calls_in_file works for example scripts",
               expected_df <-
                 data.frame(
                   foo_string = rep("calculate_costs", 2),
-                  location = paste0(relative_path, "#L", c(26, 33))
+                  test_location = paste0(relative_path, "#L", c(26, 33))
                 )
 
               # run function and store output


### PR DESCRIPTION
- Addresses the issue described in #137
- Fixes CRAN notes described in #140. This PR removes non-standard evaluation and instead declares global variables and imports functions from `rlang`, as in #140, it reverts to `base` R code.
- Closes: #141  